### PR TITLE
Migrate Cortex domain to dnr-core-ruraljurors

### DIFF
--- a/cortex.yaml
+++ b/cortex.yaml
@@ -9,7 +9,7 @@ info:
   x-cortex-tag: community-id-java
   x-cortex-type: service
   x-cortex-domain-parents:
-  - tag: Ldnr-core-ruraljurors
+  - tag: dnr-core-ruraljurors
   x-cortex-groups:
     - target:library
     - strategy:cloud

--- a/cortex.yaml
+++ b/cortex.yaml
@@ -9,7 +9,7 @@ info:
   x-cortex-tag: community-id-java
   x-cortex-type: service
   x-cortex-domain-parents:
-  - tag: idr-core-ruraljurors
+  - tag: Ldnr-core-ruraljurors
   x-cortex-groups:
     - target:library
     - strategy:cloud


### PR DESCRIPTION
Migrates cortex domain parent to dnr-core-ruraljurors in cortex.yaml.